### PR TITLE
Paranoid teleport unremoveable blocks

### DIFF
--- a/src/main/java/lol/sylvie/sswaystones/command/WaystonesCommand.java
+++ b/src/main/java/lol/sylvie/sswaystones/command/WaystonesCommand.java
@@ -147,9 +147,8 @@ public class WaystonesCommand {
                                 } else if (type == String.class) {
                                     field.set(instance, value);
                                 } else if (type == List.class) {
-                                    field.set(instance, List.of(
-                                        value.replaceAll("^\\[\\s*|\\s*]$|\"", "").split(",\\s")
-                                    ));
+                                    field.set(instance,
+                                            List.of(value.replaceAll("^\\[\\s*|\\s*]$|\"", "").split(",\\s")));
                                 }
                                 newValue = field.get(instance);
                             } catch (IllegalAccessException e) {

--- a/src/main/java/lol/sylvie/sswaystones/command/WaystonesCommand.java
+++ b/src/main/java/lol/sylvie/sswaystones/command/WaystonesCommand.java
@@ -146,6 +146,10 @@ public class WaystonesCommand {
                                     field.set(instance, Boolean.parseBoolean(value));
                                 } else if (type == String.class) {
                                     field.set(instance, value);
+                                } else if (type == List.class) {
+                                    field.set(instance, List.of(
+                                        value.replaceAll("^\\[\\s*|\\s*]$|\"", "").split(",\\s")
+                                    ));
                                 }
                                 newValue = field.get(instance);
                             } catch (IllegalAccessException e) {

--- a/src/main/java/lol/sylvie/sswaystones/config/Configuration.java
+++ b/src/main/java/lol/sylvie/sswaystones/config/Configuration.java
@@ -10,6 +10,7 @@ import com.google.gson.JsonSyntaxException;
 import com.google.gson.annotations.SerializedName;
 import java.io.*;
 import java.nio.file.Path;
+import java.util.List;
 import lol.sylvie.sswaystones.Waystones;
 import lol.sylvie.sswaystones.util.NameGenerator;
 import net.fabricmc.loader.api.FabricLoader;
@@ -77,6 +78,10 @@ public class Configuration {
         @SerializedName("paranoid_teleport")
         @Description(translation = "config.sswaystones.paranoid_teleport")
         public boolean safeTeleport = true;
+
+        @SerializedName("paranoid_teleport_unremoveable_blocks")
+        @Description(translation = "config.sswaystones.paranoid_teleport_unremoveable_blocks")
+        public List<String> safeTeleportUnremoveableBlocks = List.of();
 
         @SerializedName("remove_invalid_waystones")
         @Description(translation = "config.sswaystones.remove_invalid_waystones")

--- a/src/main/java/lol/sylvie/sswaystones/storage/WaystoneRecord.java
+++ b/src/main/java/lol/sylvie/sswaystones/storage/WaystoneRecord.java
@@ -75,13 +75,13 @@ public final class WaystoneRecord {
     // this weird workaround
     @SuppressWarnings("OptionalUsedAsFieldOrParameterType")
     private WaystoneRecord(UUID owner, String ownerName, String waystoneName, BlockPos pos, ResourceKey<Level> world,
-                           Optional<AccessSettings> accessSettings, Item icon) {
+            Optional<AccessSettings> accessSettings, Item icon) {
         this(owner, ownerName, waystoneName, pos, world,
                 accessSettings.orElseGet(() -> new AccessSettings(false, false, "")), icon);
     }
 
     public WaystoneRecord(UUID owner, String ownerName, String waystoneName, BlockPos pos, ResourceKey<Level> world,
-                          AccessSettings accessSettings, Item icon) {
+            AccessSettings accessSettings, Item icon) {
         this.owner = owner;
         this.ownerName = ownerName;
         this.setWaystoneName(waystoneName); // Limits waystone name
@@ -137,14 +137,15 @@ public final class WaystoneRecord {
         }
 
         if (config.safeTeleport) {
-            // Remove any blocks trying to suffocate the player except those marked as unremoveable
+            // Remove any blocks trying to suffocate the player except those marked as
+            // unremoveable
             List<Block> unremoveableBlocks = config.safeTeleportUnremoveableBlocks.stream()
-                    .map(x -> BuiltInRegistries.BLOCK.getValue(Identifier.parse(x)))
-                    .toList();
+                    .map(x -> BuiltInRegistries.BLOCK.getValue(Identifier.parse(x))).toList();
             BlockPos head = target.offset(0, 1, 0);
             BlockState headState = targetWorld.getBlockState(head);
             if (!headState.getCollisionShape(targetWorld, head).isEmpty()) {
-                if (headState.getDestroySpeed(targetWorld, head) != -1 && !unremoveableBlocks.contains(headState.getBlock())) {
+                if (headState.getDestroySpeed(targetWorld, head) != -1
+                        && !unremoveableBlocks.contains(headState.getBlock())) {
                     server.executeIfPossible(() -> targetWorld.destroyBlock(head, true));
                 }
             }

--- a/src/main/java/lol/sylvie/sswaystones/storage/WaystoneRecord.java
+++ b/src/main/java/lol/sylvie/sswaystones/storage/WaystoneRecord.java
@@ -29,6 +29,7 @@ import net.minecraft.core.particles.ParticleTypes;
 import net.minecraft.core.particles.PowerParticleOption;
 import net.minecraft.core.registries.BuiltInRegistries;
 import net.minecraft.network.chat.Component;
+import net.minecraft.resources.Identifier;
 import net.minecraft.resources.ResourceKey;
 import net.minecraft.server.MinecraftServer;
 import net.minecraft.server.level.ServerLevel;
@@ -42,6 +43,7 @@ import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.item.Items;
 import net.minecraft.world.item.component.ResolvableProfile;
 import net.minecraft.world.level.Level;
+import net.minecraft.world.level.block.Block;
 import net.minecraft.world.level.block.Blocks;
 import net.minecraft.world.level.block.state.BlockState;
 import net.minecraft.world.phys.Vec3;
@@ -73,13 +75,13 @@ public final class WaystoneRecord {
     // this weird workaround
     @SuppressWarnings("OptionalUsedAsFieldOrParameterType")
     private WaystoneRecord(UUID owner, String ownerName, String waystoneName, BlockPos pos, ResourceKey<Level> world,
-            Optional<AccessSettings> accessSettings, Item icon) {
+                           Optional<AccessSettings> accessSettings, Item icon) {
         this(owner, ownerName, waystoneName, pos, world,
                 accessSettings.orElseGet(() -> new AccessSettings(false, false, "")), icon);
     }
 
     public WaystoneRecord(UUID owner, String ownerName, String waystoneName, BlockPos pos, ResourceKey<Level> world,
-            AccessSettings accessSettings, Item icon) {
+                          AccessSettings accessSettings, Item icon) {
         this.owner = owner;
         this.ownerName = ownerName;
         this.setWaystoneName(waystoneName); // Limits waystone name
@@ -135,11 +137,14 @@ public final class WaystoneRecord {
         }
 
         if (config.safeTeleport) {
-            // Remove any blocks trying to suffocate the player
+            // Remove any blocks trying to suffocate the player except those marked as unremoveable
+            List<Block> unremoveableBlocks = config.safeTeleportUnremoveableBlocks.stream()
+                    .map(x -> BuiltInRegistries.BLOCK.getValue(Identifier.parse(x)))
+                    .toList();
             BlockPos head = target.offset(0, 1, 0);
             BlockState headState = targetWorld.getBlockState(head);
             if (!headState.getCollisionShape(targetWorld, head).isEmpty()) {
-                if (headState.getDestroySpeed(targetWorld, head) != -1) {
+                if (headState.getDestroySpeed(targetWorld, head) != -1 && !unremoveableBlocks.contains(headState.getBlock())) {
                     server.executeIfPossible(() -> targetWorld.destroyBlock(head, true));
                 }
             }


### PR DESCRIPTION
Sometimes paranoid teleport would break blocks that shouldn't be broken, like GOML's claims or Universal Graves' graves.

This was built on top of commit ab7c2dee454b0c557163b69c12f076e2fa924cfa but it shouldn't create any merge conflicts.