### PR TITLE
Short circuit fixSetBlockUpdating

### DIFF
--- a/src/main/java/lol/sylvie/sswaystones/mixin/LevelChunkMixin.java
+++ b/src/main/java/lol/sylvie/sswaystones/mixin/LevelChunkMixin.java
@@ -24,7 +24,8 @@ public class LevelChunkMixin {
 
     @ModifyVariable(method = "setBlockState", at = @At("STORE"), ordinal = 4)
     private boolean sswaystones$fixSetblockUpdating(boolean value, @Local(argsOnly = true) BlockPos pos) {
+        if (value) return true;
         BlockEntity blockEntity = level.getBlockEntity(pos);
-        return value || (blockEntity instanceof WaystoneBlockEntity);
+        return blockEntity instanceof WaystoneBlockEntity;
     }
 }


### PR DESCRIPTION
The following issues at least _sometimes_ seem to be caused by calling `level.getBlockEntity` before it can set up its listener class. While that's not sswaystone's fault, it might be beneficial to postpone that call if we know ahead of time that we'll be returning true?

https://github.com/sylvxa/sswaystones/issues/42
https://github.com/sylvxa/sswaystones/issues/43
https://github.com/sylvxa/sswaystones/issues/46