### PR TITLE
Add Hide Name Toggle & Port Over 26.2 Fixes

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-	id 'net.fabricmc.fabric-loom' version '1.17-SNAPSHOT'
+	id 'net.fabricmc.fabric-loom' version '1.15-SNAPSHOT'
 	id 'maven-publish'
 	id "com.diffplug.spotless" version "7.0.0.BETA1"
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -7,7 +7,7 @@ fabric.loom.multiProjectOptimisation=true
 # Fabric Properties
 # check these on https://modmuss50.me/fabric.html
 minecraft_version=26.2
-loader_version=0.19.3
+loader_version=0.18.4
 
 # Mod Properties
 mod_version = 1.3.2
@@ -16,9 +16,9 @@ archives_base_name = sswaystones
 
 ## Dependencies
 # Fabric API: https://modmuss50.me/fabric.html
-fabric_api_version=0.152.1+26.2
+fabric_api_version=0.154.0+26.2
 # Polymer (Core): https://maven.nucleoid.xyz/eu/pb4/polymer-core/
-polymer_version=0.17.0+26.2-rc-2
+polymer_version=0.17.1+26.2
 # SGUI: https://maven.nucleoid.xyz/eu/pb4/sgui/
 sgui_version=2.1.0+26.2
 # Server-Translations-API: https://maven.nucleoid.xyz/xyz/nucleoid/server-translations-api/

--- a/gradle.properties
+++ b/gradle.properties
@@ -7,7 +7,7 @@ fabric.loom.multiProjectOptimisation=true
 # Fabric Properties
 # check these on https://modmuss50.me/fabric.html
 minecraft_version=26.2
-loader_version=0.18.4
+loader_version=0.19.3
 
 # Mod Properties
 mod_version = 1.3.2
@@ -16,9 +16,9 @@ archives_base_name = sswaystones
 
 ## Dependencies
 # Fabric API: https://modmuss50.me/fabric.html
-fabric_api_version=0.154.0+26.2
+fabric_api_version=0.152.1+26.2
 # Polymer (Core): https://maven.nucleoid.xyz/eu/pb4/polymer-core/
-polymer_version=0.17.1+26.2
+polymer_version=0.17.0+26.2-rc-2
 # SGUI: https://maven.nucleoid.xyz/eu/pb4/sgui/
 sgui_version=2.1.0+26.2
 # Server-Translations-API: https://maven.nucleoid.xyz/xyz/nucleoid/server-translations-api/

--- a/gradle.properties
+++ b/gradle.properties
@@ -6,7 +6,7 @@ fabric.loom.multiProjectOptimisation=true
 
 # Fabric Properties
 # check these on https://modmuss50.me/fabric.html
-minecraft_version=26.1
+minecraft_version=26.2
 loader_version=0.18.4
 
 # Mod Properties
@@ -16,13 +16,13 @@ archives_base_name = sswaystones
 
 ## Dependencies
 # Fabric API: https://modmuss50.me/fabric.html
-fabric_api_version=0.144.3+26.1
+fabric_api_version=0.154.0+26.2
 # Polymer (Core): https://maven.nucleoid.xyz/eu/pb4/polymer-core/
-polymer_version=0.16.0-pre.4+26.1
+polymer_version=0.17.1+26.2
 # SGUI: https://maven.nucleoid.xyz/eu/pb4/sgui/
-sgui_version=2.0.0-beta.2+26.1
+sgui_version=2.1.0+26.2
 # Server-Translations-API: https://maven.nucleoid.xyz/xyz/nucleoid/server-translations-api/
-server_translations_version=3.0.3+26.1
+server_translations_version=3.1.0+26.2
 # Floodgate: https://geysermc.org/wiki/geyser/getting-started-with-the-api/
 floodgate_version=2.2.5-SNAPSHOT
 # Fabric Permissions API: https://github.com/lucko/fabric-permissions-api/tree/master

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-9.5.0-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.4.0-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/src/main/java/lol/sylvie/sswaystones/Waystones.java
+++ b/src/main/java/lol/sylvie/sswaystones/Waystones.java
@@ -36,7 +36,7 @@ public class Waystones implements ModInitializer {
 
         Runtime.getRuntime().addShutdownHook(new Thread(() -> configuration.save()));
 
-        LOGGER.info("{} is made with <3 by sylvie", MOD_ID);
+        LOGGER.info("{} is made with <3 by sylvie                        and hero brian", MOD_ID);
         ModBlocks.initialize();
         ModItems.initialize();
 

--- a/src/main/java/lol/sylvie/sswaystones/Waystones.java
+++ b/src/main/java/lol/sylvie/sswaystones/Waystones.java
@@ -36,7 +36,7 @@ public class Waystones implements ModInitializer {
 
         Runtime.getRuntime().addShutdownHook(new Thread(() -> configuration.save()));
 
-        LOGGER.info("{} is made with <3 by sylvie                        and hero brian", MOD_ID);
+        LOGGER.info("{} is made with <3 by sylvie", MOD_ID);
         ModBlocks.initialize();
         ModItems.initialize();
 

--- a/src/main/java/lol/sylvie/sswaystones/block/WaystoneBlockEntity.java
+++ b/src/main/java/lol/sylvie/sswaystones/block/WaystoneBlockEntity.java
@@ -8,18 +8,19 @@ import eu.pb4.polymer.virtualentity.api.ElementHolder;
 import eu.pb4.polymer.virtualentity.api.attachment.ChunkAttachment;
 import eu.pb4.polymer.virtualentity.api.elements.ItemDisplayElement;
 import eu.pb4.polymer.virtualentity.api.elements.TextDisplayElement;
-import java.awt.*;
 import java.util.Random;
 import lol.sylvie.sswaystones.Waystones;
 import lol.sylvie.sswaystones.storage.WaystoneRecord;
 import lol.sylvie.sswaystones.storage.WaystoneStorage;
 import lol.sylvie.sswaystones.util.HashUtil;
-import net.minecraft.ChatFormatting;
 import net.minecraft.core.BlockPos;
+import net.minecraft.core.Vec3i;
 import net.minecraft.core.component.DataComponents;
 import net.minecraft.core.particles.DustParticleOptions;
 import net.minecraft.core.particles.ParticleOptions;
 import net.minecraft.core.particles.ParticleTypes;
+import net.minecraft.network.chat.Component;
+import net.minecraft.network.chat.MutableComponent;
 import net.minecraft.server.MinecraftServer;
 import net.minecraft.server.level.ServerLevel;
 import net.minecraft.world.entity.Display;
@@ -30,6 +31,7 @@ import net.minecraft.world.level.block.entity.BlockEntity;
 import net.minecraft.world.level.block.state.BlockState;
 import net.minecraft.world.phys.Vec3;
 import net.minecraft.world.scores.PlayerTeam;
+import net.minecraft.world.scores.TeamColor;
 import org.jetbrains.annotations.Nullable;
 import org.joml.Vector3f;
 
@@ -37,6 +39,7 @@ public class WaystoneBlockEntity extends BlockEntity {
     private static final Random RANDOM = new Random();
     private final ElementHolder holder = new ElementHolder();
     private ChunkAttachment attachment;
+    private boolean lastTickNameHidden = false;
 
     public TextDisplayElement nameDisplay = null;
     public ItemDisplayElement eyeDisplay = null;
@@ -50,12 +53,14 @@ public class WaystoneBlockEntity extends BlockEntity {
     public static void tick(Level world, WaystoneBlockEntity waystoneEntity) {
         WaystoneRecord record = waystoneEntity.getThisWaystone(world);
         boolean waystoneOwned = record != null;
-        boolean shouldCreateName = record != null && waystoneEntity.nameDisplay == null;
-
+        boolean nameHidden = record.getAccessSettings().isNameHidden();
+        boolean shouldCreateName = record != null && waystoneEntity.nameDisplay == null && !nameHidden;
         // Create the display itself
-        if (waystoneEntity.eyeDisplay == null || shouldCreateName) {
+        if ((waystoneEntity.eyeDisplay == null || shouldCreateName
+                || waystoneEntity.lastTickNameHidden != nameHidden)) {
             waystoneEntity.createHologramDisplay(world);
         }
+        waystoneEntity.lastTickNameHidden = nameHidden;
 
         // Eye rotation
         // We use game time instead of just adding yaw because the display is recreated
@@ -63,39 +68,40 @@ public class WaystoneBlockEntity extends BlockEntity {
         // and it would reset jarringly if it wasn't separate from the display objects
         waystoneEntity.eyeDisplay.setYaw(((world.getGameTime() + waystoneEntity.hashCode()) % 90) * 4);
 
-        ChatFormatting color = ChatFormatting.RESET;
+        TeamColor color = null;
         if (waystoneOwned) {
             // Team coloring
             String teamName = record.getAccessSettings().getTeam();
             if (!teamName.isEmpty()) {
                 PlayerTeam team = world.getScoreboard().getPlayerTeam(teamName);
                 if (team != null) {
-                    color = team.getColor();
+                    color = team.getColor().orElse(null);
                 }
             }
 
             // TODO: Maybe cache this value?
             waystoneEntity.eyeDisplay.setItem(getDisplayIcon(world.getServer(), record));
 
-            if (waystoneEntity.nameDisplay == null)
-                return;
+            if (waystoneEntity.nameDisplay != null) {
+                MutableComponent displayName = record.getWaystoneText().copy();
+                if (color != null)
+                    displayName.withColor(color.textColor());
+                waystoneEntity.nameDisplay.setText((Component) displayName);
 
-            waystoneEntity.nameDisplay.setText(record.getWaystoneText().copy().withStyle(color));
-
-            // Bob up and down
-            double y = (Math.sin((double) System.currentTimeMillis() / 1000) / 32) + 1.55d;
-            waystoneEntity.nameDisplay.setOffset(new Vec3(0, y, 0));
+                // Bob up and down
+                double y = (Math.sin((double) System.currentTimeMillis() / 1000) / 32) + 1.55d;
+                waystoneEntity.nameDisplay.setOffset(new Vec3(0, y, 0));
+            }
         }
-
         // Particles
-        if (RANDOM.nextInt(0, waystoneOwned ? 20 : 10) == 0 && world instanceof ServerLevel serverWorld) {
-            Vec3 pos = waystoneEntity.getBlockPos().getBottomCenter().add(0, 1, 0);
-            Integer colorValue = color.getColor();
-
-            boolean noTeam = color == ChatFormatting.RESET || colorValue == null;
-            ParticleOptions options = noTeam ? ParticleTypes.PORTAL : new DustParticleOptions(colorValue, 1f);
-
-            serverWorld.sendParticles(options, pos.x(), pos.y(), pos.z(), 8, 0.1d, 0.1d, 0.1d, 0.1d);
+        if (RANDOM.nextInt(0, waystoneOwned ? 20 : 10) == 0 && world instanceof ServerLevel) {
+            ServerLevel serverWorld = (ServerLevel) world;
+            Vec3 pos = Vec3.atBottomCenterOf((Vec3i) waystoneEntity.getBlockPos()).add(0.0D, 1.0D, 0.0D);
+            boolean noTeam = (color == null);
+            ParticleOptions options = noTeam
+                    ? (ParticleOptions) ParticleTypes.PORTAL
+                    : (ParticleOptions) new DustParticleOptions(color.rgb(), 1.0F);
+            serverWorld.sendParticles(options, pos.x(), pos.y(), pos.z(), 8, 0.1D, 0.1D, 0.1D, 0.1D);
         }
     }
 
@@ -134,7 +140,8 @@ public class WaystoneBlockEntity extends BlockEntity {
 
         WaystoneRecord record = getThisWaystone(world);
         boolean exists = record != null;
-
+        assert record != null;
+        WaystoneRecord.AccessSettings accessSettings = record.getAccessSettings();
         // Eye display
         ItemStack glowingEnderPearl = Items.ENDER_PEARL.getDefaultInstance();
         glowingEnderPearl.set(DataComponents.ENCHANTMENT_GLINT_OVERRIDE, true);
@@ -148,7 +155,7 @@ public class WaystoneBlockEntity extends BlockEntity {
         holder.addElement(eyeDisplay);
 
         // Waystone name display
-        if (exists) {
+        if (!accessSettings.isNameHidden()) {
             nameDisplay = new TextDisplayElement();
 
             nameDisplay.setText(record.getWaystoneText());

--- a/src/main/java/lol/sylvie/sswaystones/block/WaystoneBlockEntity.java
+++ b/src/main/java/lol/sylvie/sswaystones/block/WaystoneBlockEntity.java
@@ -14,12 +14,10 @@ import lol.sylvie.sswaystones.storage.WaystoneRecord;
 import lol.sylvie.sswaystones.storage.WaystoneStorage;
 import lol.sylvie.sswaystones.util.HashUtil;
 import net.minecraft.core.BlockPos;
-import net.minecraft.core.Vec3i;
 import net.minecraft.core.component.DataComponents;
 import net.minecraft.core.particles.DustParticleOptions;
 import net.minecraft.core.particles.ParticleOptions;
 import net.minecraft.core.particles.ParticleTypes;
-import net.minecraft.network.chat.Component;
 import net.minecraft.network.chat.MutableComponent;
 import net.minecraft.server.MinecraftServer;
 import net.minecraft.server.level.ServerLevel;
@@ -92,7 +90,7 @@ public class WaystoneBlockEntity extends BlockEntity {
                 MutableComponent displayName = record.getWaystoneText().copy();
                 if (color != null)
                     displayName.withColor(color.textColor());
-                waystoneEntity.nameDisplay.setText((Component) displayName);
+                waystoneEntity.nameDisplay.setText((MutableComponent) displayName);
 
                 // Bob up and down
                 double y = (Math.sin((double) System.currentTimeMillis() / 1000) / 32) + 1.55d;
@@ -100,14 +98,13 @@ public class WaystoneBlockEntity extends BlockEntity {
             }
         }
         // Particles
-        if (RANDOM.nextInt(0, waystoneOwned ? 20 : 10) == 0 && world instanceof ServerLevel) {
-            ServerLevel serverWorld = (ServerLevel) world;
-            Vec3 pos = Vec3.atBottomCenterOf((Vec3i) waystoneEntity.getBlockPos()).add(0.0D, 1.0D, 0.0D);
-            boolean noTeam = (color == null);
-            ParticleOptions options = noTeam
-                    ? (ParticleOptions) ParticleTypes.PORTAL
-                    : (ParticleOptions) new DustParticleOptions(color.rgb(), 1.0F);
-            serverWorld.sendParticles(options, pos.x(), pos.y(), pos.z(), 8, 0.1D, 0.1D, 0.1D, 0.1D);
+        if (RANDOM.nextInt(0, waystoneOwned ? 20 : 10) == 0 && world instanceof ServerLevel serverWorld) {
+            Vec3 pos = Vec3.atBottomCenterOf(waystoneEntity.getBlockPos()).add(0, 1, 0);
+
+            boolean noTeam = color == null;
+            ParticleOptions options = noTeam ? ParticleTypes.PORTAL : new DustParticleOptions(color.rgb(), 1f);
+
+            serverWorld.sendParticles(options, pos.x(), pos.y(), pos.z(), 8, 0.1d, 0.1d, 0.1d, 0.1d);
         }
     }
 

--- a/src/main/java/lol/sylvie/sswaystones/block/WaystoneBlockEntity.java
+++ b/src/main/java/lol/sylvie/sswaystones/block/WaystoneBlockEntity.java
@@ -53,7 +53,13 @@ public class WaystoneBlockEntity extends BlockEntity {
     public static void tick(Level world, WaystoneBlockEntity waystoneEntity) {
         WaystoneRecord record = waystoneEntity.getThisWaystone(world);
         boolean waystoneOwned = record != null;
-        boolean nameHidden = record.getAccessSettings().isNameHidden();
+        boolean nameHidden;
+        if (waystoneOwned) {
+            nameHidden = record.getAccessSettings().isNameHidden();
+        } else {
+            nameHidden = false;
+        }
+
         boolean shouldCreateName = record != null && waystoneEntity.nameDisplay == null && !nameHidden;
         // Create the display itself
         if ((waystoneEntity.eyeDisplay == null || shouldCreateName
@@ -140,8 +146,12 @@ public class WaystoneBlockEntity extends BlockEntity {
 
         WaystoneRecord record = getThisWaystone(world);
         boolean exists = record != null;
-        assert record != null;
-        WaystoneRecord.AccessSettings accessSettings = record.getAccessSettings();
+        boolean nameHidden;
+        if (exists) {
+            nameHidden = record.getAccessSettings().isNameHidden();
+        } else {
+            nameHidden = false;
+        }
         // Eye display
         ItemStack glowingEnderPearl = Items.ENDER_PEARL.getDefaultInstance();
         glowingEnderPearl.set(DataComponents.ENCHANTMENT_GLINT_OVERRIDE, true);
@@ -155,7 +165,7 @@ public class WaystoneBlockEntity extends BlockEntity {
         holder.addElement(eyeDisplay);
 
         // Waystone name display
-        if (!accessSettings.isNameHidden()) {
+        if (exists && !nameHidden) {
             nameDisplay = new TextDisplayElement();
 
             nameDisplay.setText(record.getWaystoneText());

--- a/src/main/java/lol/sylvie/sswaystones/block/WaystoneBlockEntity.java
+++ b/src/main/java/lol/sylvie/sswaystones/block/WaystoneBlockEntity.java
@@ -19,6 +19,7 @@ import net.minecraft.core.component.DataComponents;
 import net.minecraft.core.particles.DustParticleOptions;
 import net.minecraft.core.particles.ParticleOptions;
 import net.minecraft.core.particles.ParticleTypes;
+import net.minecraft.network.chat.Component;
 import net.minecraft.network.chat.MutableComponent;
 import net.minecraft.server.MinecraftServer;
 import net.minecraft.server.level.ServerLevel;
@@ -87,13 +88,11 @@ public class WaystoneBlockEntity extends BlockEntity {
             // TODO: Maybe cache this value?
             waystoneEntity.eyeDisplay.setItem(getDisplayIcon(world.getServer(), record));
 
-            if (waystoneEntity.nameDisplay == null)
-                return;
-
-            MutableComponent displayName = record.getWaystoneText().copy();
-            if (color != null)
-                displayName.withColor(color.textColor());
-            waystoneEntity.nameDisplay.setText(displayName);
+            if (waystoneEntity.nameDisplay != null) {
+                MutableComponent displayName = record.getWaystoneText().copy();
+                if (color != null)
+                    displayName.withColor(color.textColor());
+                waystoneEntity.nameDisplay.setText((Component) displayName);
 
                 // Bob up and down
                 double y = (Math.sin((double) System.currentTimeMillis() / 1000) / 32) + 1.55d;
@@ -101,13 +100,14 @@ public class WaystoneBlockEntity extends BlockEntity {
             }
         }
         // Particles
-        if (RANDOM.nextInt(0, waystoneOwned ? 20 : 10) == 0 && world instanceof ServerLevel serverWorld) {
-            Vec3 pos = Vec3.atBottomCenterOf(waystoneEntity.getBlockPos()).add(0, 1, 0);
-
-            boolean noTeam = color == null;
-            ParticleOptions options = noTeam ? ParticleTypes.PORTAL : new DustParticleOptions(color.rgb(), 1f);
-
-            serverWorld.sendParticles(options, pos.x(), pos.y(), pos.z(), 8, 0.1d, 0.1d, 0.1d, 0.1d);
+        if (RANDOM.nextInt(0, waystoneOwned ? 20 : 10) == 0 && world instanceof ServerLevel) {
+            ServerLevel serverWorld = (ServerLevel) world;
+            Vec3 pos = Vec3.atBottomCenterOf((Vec3i) waystoneEntity.getBlockPos()).add(0.0D, 1.0D, 0.0D);
+            boolean noTeam = (color == null);
+            ParticleOptions options = noTeam
+                    ? (ParticleOptions) ParticleTypes.PORTAL
+                    : (ParticleOptions) new DustParticleOptions(color.rgb(), 1.0F);
+            serverWorld.sendParticles(options, pos.x(), pos.y(), pos.z(), 8, 0.1D, 0.1D, 0.1D, 0.1D);
         }
     }
 

--- a/src/main/java/lol/sylvie/sswaystones/gui/JavaViewerGui.java
+++ b/src/main/java/lol/sylvie/sswaystones/gui/JavaViewerGui.java
@@ -89,7 +89,7 @@ public class JavaViewerGui extends SimpleGui {
         }
 
         for (int i = 45; i < 54; i++) {
-            this.setSlot(i, new GuiElementBuilder(Items.GRAY_STAINED_GLASS_PANE).setName(Component.empty()));
+            this.setSlot(i, new GuiElementBuilder(Items.STAINED_GLASS_PANE.gray()).setName(Component.empty()));
         }
 
         // Gui controls
@@ -195,7 +195,7 @@ public class JavaViewerGui extends SimpleGui {
 
         private void updateMenu() {
             for (int i = 0; i < 9; i++) {
-                this.setSlot(i, new GuiElementBuilder(Items.GRAY_STAINED_GLASS_PANE).setName(Component
+                this.setSlot(i, new GuiElementBuilder(Items.STAINED_GLASS_PANE.gray()).setName(Component
                         .translatable("gui.sswaystones.change_icon_instruction").withStyle(ChatFormatting.GRAY)));
             }
             this.setSlot(4, waystone.getIconOrHead(player.level().getServer()));
@@ -237,7 +237,7 @@ public class JavaViewerGui extends SimpleGui {
         private void updateMenu() {
             // Framing
             for (int i = 0; i < (9 * 3); i++) {
-                this.setSlot(i, new GuiElementBuilder(Items.GRAY_STAINED_GLASS_PANE).setName(Component
+                this.setSlot(i, new GuiElementBuilder(Items.STAINED_GLASS_PANE.gray()).setName(Component
                         .translatable("gui.sswaystones.access_settings_instruction").withStyle(ChatFormatting.GRAY)));
             }
 
@@ -296,6 +296,19 @@ public class JavaViewerGui extends SimpleGui {
                 slot += 1;
             }
 
+            if (Permissions.check(player, "sswaystones.create.hidename", true)) {
+                GuiElementBuilder hiddenToggle = new GuiElementBuilder(Items.NAME_TAG)
+                        .setName(Component.translatable("gui.sswaystones.toggle_hidename")
+                                .withStyle(accessSettings.isNameHidden() ? ChatFormatting.GREEN : ChatFormatting.RED));
+
+                hiddenToggle.setCallback((index, type, action, gui) -> {
+                    accessSettings.setNameHidden(!accessSettings.isNameHidden());
+                    this.updateMenu();
+                });
+                this.setSlot(slot, hiddenToggle);
+                slot += 1;
+            }
+
             // If no settings were available
             if (slot == 10) {
                 this.setSlot(13,
@@ -332,7 +345,7 @@ public class JavaViewerGui extends SimpleGui {
 
         private void updateMenu() {
             for (int i = 0; i < (9 * 3); i++) {
-                this.setSlot(i, new GuiElementBuilder(Items.GRAY_STAINED_GLASS_PANE).setName(Component.empty()));
+                this.setSlot(i, new GuiElementBuilder(Items.STAINED_GLASS_PANE.gray()).setName(Component.empty()));
             }
 
             this.setSlot(10,

--- a/src/main/java/lol/sylvie/sswaystones/gui/compat/BedrockViewerGui.java
+++ b/src/main/java/lol/sylvie/sswaystones/gui/compat/BedrockViewerGui.java
@@ -134,6 +134,11 @@ public class BedrockViewerGui {
             builder.toggle("Server-Owned", accessSettings.isServerOwned());
         }
 
+        boolean hideNameAvailable = Permissions.check(player, "sswaystones.create.hidename", true);
+        if (hideNameAvailable) {
+            builder.toggle("Hide Name", accessSettings.isGlobal());
+        }
+
         builder.validResultHandler(response -> {
             String name = response.asInput();
             if (name == null)
@@ -160,6 +165,11 @@ public class BedrockViewerGui {
             if (serverAvailable) {
                 boolean server = response.asToggle(index);
                 accessSettings.setServerOwned(server);
+            }
+
+            if (hideNameAvailable) {
+                boolean hideName = response.asToggle(index);
+                accessSettings.setNameHidden(hideName);
             }
 
             waystone.setWaystoneName(name);

--- a/src/main/java/lol/sylvie/sswaystones/storage/WaystoneRecord.java
+++ b/src/main/java/lol/sylvie/sswaystones/storage/WaystoneRecord.java
@@ -185,7 +185,7 @@ public final class WaystoneRecord {
             }
         }
         // Teleport!
-        Vec3 center = Vec3.atBottomCenterOf((Vec3i) target);
+        Vec3 center = Vec3.atBottomCenterOf(target);
         player.teleportTo(targetWorld, center.x(), center.y(), center.z(), Set.of(), player.getYRot(), player.getXRot(),
                 false);
         targetWorld.playSound(null, target, SoundEvents.ENDERMAN_TELEPORT, SoundSource.PLAYERS, 1f, 1f);

--- a/src/main/java/lol/sylvie/sswaystones/storage/WaystoneRecord.java
+++ b/src/main/java/lol/sylvie/sswaystones/storage/WaystoneRecord.java
@@ -185,7 +185,7 @@ public final class WaystoneRecord {
             }
         }
         // Teleport!
-        Vec3 center = Vec3.atBottomCenterOf(target);
+        Vec3 center = Vec3.atBottomCenterOf((Vec3i) target);
         player.teleportTo(targetWorld, center.x(), center.y(), center.z(), Set.of(), player.getYRot(), player.getXRot(),
                 false);
         targetWorld.playSound(null, target, SoundEvents.ENDERMAN_TELEPORT, SoundSource.PLAYERS, 1f, 1f);

--- a/src/main/java/lol/sylvie/sswaystones/storage/WaystoneRecord.java
+++ b/src/main/java/lol/sylvie/sswaystones/storage/WaystoneRecord.java
@@ -78,7 +78,7 @@ public final class WaystoneRecord {
     private WaystoneRecord(UUID owner, String ownerName, String waystoneName, BlockPos pos, ResourceKey<Level> world,
             Optional<AccessSettings> accessSettings, Item icon) {
         this(owner, ownerName, waystoneName, pos, world,
-                accessSettings.orElseGet(() -> new AccessSettings(false, false, "")), icon);
+                accessSettings.orElseGet(() -> new AccessSettings(false, false, "", false)), icon);
     }
 
     public WaystoneRecord(UUID owner, String ownerName, String waystoneName, BlockPos pos, ResourceKey<Level> world,
@@ -184,9 +184,8 @@ public final class WaystoneRecord {
                 break;
             }
         }
-
         // Teleport!
-        Vec3 center = target.getBottomCenter();
+        Vec3 center = Vec3.atBottomCenterOf((Vec3i) target);
         player.teleportTo(targetWorld, center.x(), center.y(), center.z(), Set.of(), player.getYRot(), player.getXRot(),
                 false);
         targetWorld.playSound(null, target, SoundEvents.ENDERMAN_TELEPORT, SoundSource.PLAYERS, 1f, 1f);
@@ -273,17 +272,20 @@ public final class WaystoneRecord {
         private boolean global; // Blanket flag, allows all players to access
         private boolean server; // Hides the actual owner and makes it unbreakable
         private String team; // Scoreboard team
+        private boolean hideName; // Hide name
 
         public static final Codec<AccessSettings> CODEC = RecordCodecBuilder.create(instance -> instance
                 .group(Codec.BOOL.fieldOf("global").forGetter(AccessSettings::isGlobal),
                         Codec.BOOL.fieldOf("server").forGetter(AccessSettings::isServerOwned),
-                        Codec.STRING.fieldOf("team").forGetter(AccessSettings::getTeam))
+                        Codec.STRING.fieldOf("team").forGetter(AccessSettings::getTeam),
+                        Codec.BOOL.fieldOf("hideName").forGetter(AccessSettings::isNameHidden))
                 .apply(instance, AccessSettings::new));
 
-        public AccessSettings(boolean global, boolean server, String team) {
+        public AccessSettings(boolean global, boolean server, String team, boolean hideName) {
             this.global = global;
             this.server = server;
             this.team = team;
+            this.hideName = hideName;
         }
 
         public boolean isEffectivelyGlobal() {
@@ -335,6 +337,14 @@ public final class WaystoneRecord {
 
         public boolean hasTeam() {
             return !this.getTeam().isEmpty();
+        }
+
+        public void setNameHidden(boolean nameHidden) {
+            this.hideName = nameHidden;
+        }
+
+        public boolean isNameHidden() {
+            return this.hideName;
         }
     }
 

--- a/src/main/java/lol/sylvie/sswaystones/storage/WaystoneStorage.java
+++ b/src/main/java/lol/sylvie/sswaystones/storage/WaystoneStorage.java
@@ -105,7 +105,7 @@ public class WaystoneStorage extends SavedData {
 
         WaystoneRecord record = new WaystoneRecord(player.getUUID(), player.getName().getString(),
                 NameGenerator.generateName(), pos, world.dimension(),
-                new WaystoneRecord.AccessSettings(false, false, ""), Items.PLAYER_HEAD);
+                new WaystoneRecord.AccessSettings(false, false, "", false), Items.PLAYER_HEAD);
         String hash = record.getHash();
         this.waystones.put(hash, record);
 

--- a/src/main/resources/data/sswaystones/lang/en_us.json
+++ b/src/main/resources/data/sswaystones/lang/en_us.json
@@ -34,6 +34,7 @@
   "gui.sswaystones.toggle_global": "Global",
   "gui.sswaystones.toggle_team": "Team-accessible",
   "gui.sswaystones.toggle_server": "Server-Owned",
+  "gui.sswaystones.toggle_hidename": "Hide Name",
   "gui.sswaystones.forget_waystone": "Forget Waystone? (%s)",
   "command.sswaystones.waystone_not_found": "That waystone does not exist!",
   "command.sswaystones.waystone_removed_successfully": "Waystone was removed!",


### PR DESCRIPTION
Originally I was just gonna add the Hide Name Toggle in access settings for use on my school smp (vanilla anarchy on 26.2) since bedrock players can see the name through walls.

I ended up taking a decompiler to the 26.2 jar on modrinth since I'm guessing you forgot to commit it/haven't committed it yet, and surgically transplanting the things that needed changing

no translations for other languages for the change, I don't know the other languages in the lang files and I'd rather let someone who knows what they're doing with that have at it